### PR TITLE
fix for ampersand in video filename  #23

### DIFF
--- a/mythroku/player_feed.php
+++ b/mythroku/player_feed.php
@@ -280,7 +280,14 @@ class resultLength extends XmlEmitter {}
 class endIndex extends XmlEmitter {}
 
 class title extends XmlEmitter {}
-class contentId extends XmlEmitter {}
+class contentId extends XmlEmitter {
+	public function __construct(){
+		$arguments = func_get_args();		
+		$arguments[0]['content'] = crc32($arguments[0]['content']);
+		
+		parent::__construct($arguments[0]);
+	}
+}
 class contentType extends XmlEmitter {} //TV,Movie
 class contentQuality extends XmlEmitter {} //SD,HD
 class synopsis extends XmlEmitter {}


### PR DESCRIPTION
the filename is used to track the position for playback in a variable called contentId. This is stored in the Roku registry. Either the ampersnd is an illegal character there, or some other problem in the UI code, but to maintain compatibility with the production private channel I used PHP crc32 to calculate the contentId from the filename so that only numeric standard characters are ever sent to the Roku. This has the added benefit of reducing our usage of the Roku registry storage. It will cancel existing playback positions though.
