### PR TITLE
fix for literal access to array for PHP 5.4

### DIFF
--- a/mythroku/mythtv_weather_xml.php
+++ b/mythroku/mythtv_weather_xml.php
@@ -124,8 +124,9 @@ if(isset($_GET['Weather'])) {
 			);
 		}else{
 			$msg = (string)$weatherList->xpath('//error/type')[0];
-			if(!empty($weatherList->xpath('//error/description'))) 
-				$msg .= ':' . (string)$weatherList->xpath('//error/description')[0];
+			$desc = (string)$weatherList->xpath('//error/description')[0];
+			if(!empty($desc)) 
+				$msg .= ': $desc';
 			$info = new ProgramTpl(new SimpleXMLElement(ProgramTpl::rsERROR));
 			$info->Title = "Exception";
 			$info->Description = $msg; 


### PR DESCRIPTION
used Fedora 18, PHP 5.4.23
