### PR TITLE
expose episodic info in UI

### DIFF
--- a/mythroku/player_feed.php
+++ b/mythroku/player_feed.php
@@ -241,7 +241,7 @@ class item extends XmlEmitter {
 			$this->contentType = new contentType(array('content'=>'TV'));
 			$this->media->streamUrl->setContent("$streamUrl "); //yes the space is required
 			$this->synopsis = new synopsis(array('content'=>normalizeHtml($show->description)));
-			$this->genres = new genres(array('content'=>normalizeHtml($show->category)));
+			$this->genres = new genres(array('content'=>normalizeHtml($show->category.' ('.$show->programid.')')));
 			$this->runtime = new runtime(array('content'=>$ShowLength));
 			$this->date = new date(array('content'=>date("F j, Y, g:i a", convert_datetime($show->starttime))));
 			$this->programid = new programid(array('content'=>$show->programid));
@@ -287,10 +287,17 @@ class item extends XmlEmitter {
 			$this->contentType = new contentType(array('content'=>'Movie'));
 			$this->media->streamUrl->setContent("$streamUrl "); //yes the space is required
 			$this->synopsis = new synopsis(array('content'=>normalizeHtml($show->plot)));
-			$this->genres = new genres(array('content'=>normalizeHtml(empty($category->category) ? '':$category->category)));
+			$season = '(S'.$show->season.'E'.$show->episode.')';
+			$this->genres = new genres(array('content'=>normalizeHtml(empty($category->category) ? '':$category->category).' '.$season));
 			$this->runtime = new runtime(array('content'=>$show->length * 60));
 			$this->date = new date(array('content'=>date("Y-m-d", convert_datetime($show->starttime))));
-			$this->programid = new programid(array('content'=>$show->season.'.'.$show->episode));
+			$this->programid = new programid(
+				array('content'=>
+						sprintf("%02d", $show->season)
+						.'.'
+						.sprintf("%03d",$show->episode)
+				)
+			);
 			$this->tvormov = new tvormov(array('content'=>'movie'));
 			$this->starrating = new starrating(array('content'=>$show->userrating * 10));
 		}else{


### PR DESCRIPTION
append Season/Episode or ProgramID to Category.  This maintains compatibility to the private channel originally deployed and does not require a side-load of the UI roku app